### PR TITLE
Adding encoding options to jedis

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,6 @@ high-volume ETLs which only use `GET`, `SET` and `DEL`.
 
 - Everything is stringly typed.
 
-#### TODO
-
-- Decide on serialization strategy.
-  - Similar to [lebowski](https://github.com/theladders/lebowski) with
-    declarative namespaces and encoding in the config?
-  - Something at runtime like carmine but not as bad?
-
 ## Development
 
 You can interact with the library in the REPL by typing in Emacs:

--- a/dev/dev.clj
+++ b/dev/dev.clj
@@ -1,9 +1,12 @@
 (ns dev
   (:require [clojure.tools.namespace.repl :refer [refresh refresh-all]]
             [com.stuartsierra.component :as component]
+            [org.purefn.bridges.api :as bridges]
             [org.purefn.bridges.protocol :as proto]
             [org.purefn.starman.carmine :as carmine]
             [org.purefn.starman.jedis :as jedis]
+            [taoensso.nippy :as nippy]
+            [taoensso.nippy.encryption :as enc]
             [taoensso.timbre :as log]))
 
 (defn default-system
@@ -11,7 +14,8 @@
   (component/system-map
    :carmine (carmine/redis {::carmine/host "localhost"
                             ::carmine/port 6379})
-   :jedis (jedis/redis {::jedis/host "localhost"})))
+   :jedis (jedis/redis {::jedis/host "localhost"
+                        ::jedis/namespaces {"test" {::jedis/encoder :nippy}}})))
 
 (def system
   "A Var containing an object representing the application under

--- a/project.clj
+++ b/project.clj
@@ -10,6 +10,7 @@
                  [com.stuartsierra/component "0.3.2"]
                  [com.taoensso/timbre "4.8.0"]
                  [com.taoensso/carmine "2.14.0"]
+                 [com.taoensso/encore "2.120.0"]
                  [org.clojure/test.check "0.9.0"]
                  [org.purefn/bridges "1.13.0"]
                  [org.purefn/kurosawa.core "2.0.11"]

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,6 @@
                  [com.stuartsierra/component "0.3.2"]
                  [com.taoensso/timbre "4.8.0"]
                  [com.taoensso/carmine "2.14.0"]
-                 [com.taoensso/encore "2.120.0"]
                  [org.clojure/test.check "0.9.0"]
                  [org.purefn/bridges "1.13.0"]
                  [org.purefn/kurosawa.core "2.0.11"]

--- a/src/org/purefn/starman/jedis.clj
+++ b/src/org/purefn/starman/jedis.clj
@@ -138,9 +138,10 @@
 
   (write [this ns k value]
     (with-open [c (.getResource pool)]
-      (let [fk (common/full-key ns k)]
-        (set* c fk (encode (encoder config ns) value))
-        (get-decoded c fk (encoder config ns)))))
+      (let [fk (common/full-key ns k)
+            enc (encoder config ns)]
+        (set* c fk (encode enc value))
+        (get-decoded c fk enc))))
 
   bridges/Cache
   (expire [this ns k ttl]

--- a/src/org/purefn/starman/jedis.clj
+++ b/src/org/purefn/starman/jedis.clj
@@ -78,16 +78,15 @@
   [{:keys [config ^JedisPool pool]} ns k f]
   (with-open [^Jedis c (.getResource pool)]
     (let [^String fk (common/full-key ns k)
-          cur (get-decoded c fk (encoder config ns))
+          enc (encoder config ns)
+          cur (get-decoded c fk enc)
           _ (.watch c (into-array String [fk]))
           t (.multi c)
-          _ (->> (f cur)
-                 (encode (encoder config ns))
-                 (set* t fk))
+          _ (->> (f cur) (encode enc) (set* t fk))
           res (.get t fk)]
       (if-not (seq (.exec t))
         (log/warn :temporary-failure "swap-in" :key fk :reason :cas-mismatch)
-        (get-decoded c fk (encoder config ns))))))
+        (get-decoded c fk enc)))))
 
 ;;------------------------------------------------------------------------------
 ;; Component

--- a/src/org/purefn/starman/jedis.clj
+++ b/src/org/purefn/starman/jedis.clj
@@ -146,8 +146,7 @@
     (with-open [c (.getResource pool)]
       (let [fk (common/full-key ns k)
             enc (encoder config ns)]
-        (set* c fk (encode enc value))
-        (get-decoded c fk enc))))
+        (set* c fk (encode enc value)))))
 
   bridges/Cache
   (expire [this ns k ttl]

--- a/src/org/purefn/starman/jedis.clj
+++ b/src/org/purefn/starman/jedis.clj
@@ -89,10 +89,10 @@
           _ (.watch c (into-array String [fk]))
           t (.multi c)
           _ (->> (f cur) (encode enc) (set* t fk))
-          res (.get t fk)]
+          res (.get t (.getBytes fk))]
       (if-not (seq (.exec t))
         (log/warn :temporary-failure "swap-in" :key fk :reason :cas-mismatch)
-        (get-decoded c fk enc)))))
+        (some->> (.get res) (decode enc))))))
 
 ;;------------------------------------------------------------------------------
 ;; Component

--- a/src/org/purefn/starman/jedis.clj
+++ b/src/org/purefn/starman/jedis.clj
@@ -8,8 +8,8 @@
             [org.purefn.kurosawa.health :as health]
             [org.purefn.kurosawa.k8s :as k8s]
             [org.purefn.starman.common :as common]
-            [taoensso.timbre :as log]
-            [taoensso.nippy :as nippy])
+            [taoensso.nippy :as nippy]
+            [taoensso.timbre :as log])
   (:import [java.util.concurrent ThreadLocalRandom]
            [redis.clients.jedis Jedis JedisPool JedisPoolConfig]
            [redis.clients.util SafeEncoder]))

--- a/src/org/purefn/starman/jedis.clj
+++ b/src/org/purefn/starman/jedis.clj
@@ -175,7 +175,15 @@
        (rename-keys {:host ::host}))))
 
 (defn redis
-  "Creates a Redis component from a config."
+  "Creates a Redis component from a config.
+
+  * ::host          Redis host (required)
+  * ::port          Redis port (default 6379)
+  * ::max-total     Max total connections (default 32)
+  * ::max-retries   Max retries performed on swap-in failure (default 7)
+  * ::busy-delay-ms Milliseconds of backoff during retries (default 20)
+  * ::namespaces    Map of namespace strings to encoding config (optional)
+    * ::encoder     One of :nippy, :edn"
   ([]
     (redis (default-config)))
   ([config]

--- a/src/org/purefn/starman/jedis.clj
+++ b/src/org/purefn/starman/jedis.clj
@@ -12,7 +12,7 @@
             [taoensso.nippy :as nippy])
   (:import [java.util.concurrent ThreadLocalRandom]
            [redis.clients.jedis Jedis JedisPool JedisPoolConfig]
-           (redis.clients.util SafeEncoder)))
+           [redis.clients.util SafeEncoder]))
 
 ;;------------------------------------------------------------------------------
 ;; Config
@@ -34,13 +34,13 @@
 
 (defmethod encode :default [_ val] val)
 
-(defmulti decode (fn [encoder blob] encoder))
+(defmulti decode (fn [encoder ^bytes ba] encoder))
 
-(defmethod decode :nippy [_ b]
-  (nippy/thaw b))
+(defmethod decode :nippy [_ ^bytes ba]
+  (nippy/thaw ba))
 
-(defmethod decode :default [_ ^bytes b]
-  (SafeEncoder/encode b))
+(defmethod decode :default [_ ^bytes ba]
+  (SafeEncoder/encode ba))
 
 (defn- random-sleep
   [max-duration-ms]

--- a/src/org/purefn/starman/jedis.clj
+++ b/src/org/purefn/starman/jedis.clj
@@ -59,7 +59,8 @@
         (random-sleep ms)
         (recur (inc cnt) (backoff ms))))))
 
-(defn- get*
+(defn- get* ^bytes
+  "Returns value at given key as byte array"
   [^Jedis c ^String k]
   (.get c (.getBytes k)))
 

--- a/src/org/purefn/starman/jedis.clj
+++ b/src/org/purefn/starman/jedis.clj
@@ -21,7 +21,7 @@
 (defn- encoder
   "Extracts encoder from config"
   [config ns]
-  (get-in config [:namespaces ns ::encoder]))
+  (get-in config [:namespaces ns :encoder]))
 
 ;;------------------------------------------------------------------------------
 ;; Encoding
@@ -205,7 +205,7 @@
 (s/def ::max-total pos-int?)
 
 (s/def ::encoder #{:nippy :edn})
-(s/def ::namespace-config (s/keys :req [::encoder]))
+(s/def ::namespace-config (s/keys :req-un [::encoder]))
 (s/def ::namespace string?)
 (s/def ::namespaces (s/map-of ::namespace ::namespace-config))
 

--- a/src/org/purefn/starman/jedis.clj
+++ b/src/org/purefn/starman/jedis.clj
@@ -146,7 +146,8 @@
     (with-open [c (.getResource pool)]
       (let [fk (common/full-key ns k)
             enc (encoder config ns)]
-        (set* c fk (encode enc value)))))
+        (set* c fk (encode enc value))
+        value)))
 
   bridges/Cache
   (expire [this ns k ttl]

--- a/src/org/purefn/starman/jedis.clj
+++ b/src/org/purefn/starman/jedis.clj
@@ -32,12 +32,19 @@
 (defmethod encode :nippy [_ val]
   (nippy/freeze val))
 
+(defmethod encode :edn [_ val]
+  (pr-str val))
+
 (defmethod encode :default [_ val] val)
 
 (defmulti decode (fn [encoder ^bytes ba] encoder))
 
 (defmethod decode :nippy [_ ^bytes ba]
   (nippy/thaw ba))
+
+(defmethod decode :edn [_ ^bytes ba]
+  (-> (SafeEncoder/encode ba)
+      read-string))
 
 (defmethod decode :default [_ ^bytes ba]
   (SafeEncoder/encode ba))
@@ -60,7 +67,6 @@
         (recur (inc cnt) (backoff ms))))))
 
 (defn- get* ^bytes
-  "Returns value at given key as byte array"
   [^Jedis c ^String k]
   (.get c (.getBytes k)))
 
@@ -197,7 +203,7 @@
 
 (s/def ::max-total pos-int?)
 
-(s/def ::encoder #{:nippy})
+(s/def ::encoder #{:nippy :edn})
 (s/def ::namespace-config (s/keys :req [::encoder]))
 (s/def ::namespace string?)
 (s/def ::namespaces (s/map-of ::namespace ::namespace-config))

--- a/test/org/purefn/starman/api_test.clj
+++ b/test/org/purefn/starman/api_test.clj
@@ -26,9 +26,9 @@
                             ::carmine/port 6379})
    :jedis (jedis/redis {::jedis/host "localhost"
                         ::jedis/namespaces {nippy-ns
-                                            {::jedis/encoder :nippy}
+                                            {:encoder :nippy}
                                             edn-ns
-                                            {::jedis/encoder :edn}}})))
+                                            {:encoder :edn}}})))
 
 (defn ttl-test
   [rd]
@@ -74,8 +74,7 @@
     (testing "Full stress data set encodes correctly with Nippy"
       (let [data nippy/stress-data-comparable
             k "stress"]
-        (is (= (bridges/write (:jedis sys) nippy-ns k data)
-               data))
+        (bridges/write (:jedis sys) nippy-ns k data)
         (is (= (bridges/fetch (:jedis sys) nippy-ns k)
                data))
 
@@ -93,8 +92,7 @@
     (testing "Data set encodes correctly with edn"
       (let [data edn-stress-data
             k "stress"]
-        (is (= (bridges/write (:jedis sys) edn-ns k data)
-               data))
+        (bridges/write (:jedis sys) edn-ns k data)
         (is (= (bridges/fetch (:jedis sys) edn-ns k)
                data))
 

--- a/test/org/purefn/starman/api_test.clj
+++ b/test/org/purefn/starman/api_test.clj
@@ -80,6 +80,13 @@
 
         (bridges/destroy (:jedis sys) nippy-ns k)
 
+        (is (nil? (bridges/fetch (:jedis sys) nippy-ns k)))
+
+        (is (= (bridges/swap-in (:jedis sys) nippy-ns k (constantly data))
+               data))
+
+        (bridges/destroy (:jedis sys) nippy-ns k)
+
         (is (nil? (bridges/fetch (:jedis sys) nippy-ns k)))))
 
     (testing "Data set encodes correctly with edn"
@@ -87,6 +94,13 @@
             k "stress"]
         (bridges/write (:jedis sys) edn-ns k data)
         (is (= (bridges/fetch (:jedis sys) edn-ns k)
+               data))
+
+        (bridges/destroy (:jedis sys) edn-ns k)
+
+        (is (nil? (bridges/fetch (:jedis sys) edn-ns k)))
+
+        (is (= (bridges/swap-in (:jedis sys) nippy-ns k (constantly data))
                data))
 
         (bridges/destroy (:jedis sys) edn-ns k)

--- a/test/org/purefn/starman/api_test.clj
+++ b/test/org/purefn/starman/api_test.clj
@@ -74,7 +74,8 @@
     (testing "Full stress data set encodes correctly with Nippy"
       (let [data nippy/stress-data-comparable
             k "stress"]
-        (bridges/write (:jedis sys) nippy-ns k data)
+        (is (= (bridges/write (:jedis sys) nippy-ns k data)
+               data))
         (is (= (bridges/fetch (:jedis sys) nippy-ns k)
                data))
 
@@ -92,7 +93,8 @@
     (testing "Data set encodes correctly with edn"
       (let [data edn-stress-data
             k "stress"]
-        (bridges/write (:jedis sys) edn-ns k data)
+        (is (= (bridges/write (:jedis sys) edn-ns k data)
+               data))
         (is (= (bridges/fetch (:jedis sys) edn-ns k)
                data))
 


### PR DESCRIPTION
Couple notes here:
- I didn't love having to change the `.get` API and using a default decoder to turn bytes->string, but I needed bytes for the nippy implementation and didn't want 2 places were functionality split based on encoder
- I know that I shouldn't update the contract, but all of our other KV implementations return the stored value on `write` while this was originally returning the redis response ("OK"). I looked for usages and couldn't find anything using this response value. And I know that this is open source and shouldn't depend on Ladders usage but we're still the primary consumer.