### PR TITLE
Additional config options

### DIFF
--- a/dev/dev.clj
+++ b/dev/dev.clj
@@ -16,8 +16,8 @@
                             ::carmine/port 6379})
    :jedis (jedis/redis {::jedis/host "localhost"
                         ::jedis/max-total 50
-                        ::jesis/max-idle 20
-                        ::jedis/connect-timeout-ms 3000
+                        ::jedis/max-idle 20
+                        ::jedis/timeout-ms 3000
                         ::jedis/namespaces {"test" {:encoder :nippy}}})))
 
 (def system

--- a/dev/dev.clj
+++ b/dev/dev.clj
@@ -15,7 +15,10 @@
    :carmine (carmine/redis {::carmine/host "localhost"
                             ::carmine/port 6379})
    :jedis (jedis/redis {::jedis/host "localhost"
-                        ::jedis/namespaces {"test" {::jedis/encoder :nippy}}})))
+                        ::jedis/max-total 50
+                        ::jesis/max-idle 20
+                        ::jedis/connect-timeout-ms 3000
+                        ::jedis/namespaces {"test" {:encoder :nippy}}})))
 
 (def system
   "A Var containing an object representing the application under

--- a/src/org/purefn/starman/common.clj
+++ b/src/org/purefn/starman/common.clj
@@ -9,6 +9,8 @@
 
 (def default-port 6379)
 (def default-max-total 32)
+(def default-max-idle 32)
+(def default-timeout 2000)
 
 ;;------------------------------------------------------------------------------
 ;; Helpers

--- a/src/org/purefn/starman/common.clj
+++ b/src/org/purefn/starman/common.clj
@@ -9,8 +9,7 @@
 
 (def default-port 6379)
 (def default-max-total 32)
-(def default-max-idle 32)
-(def default-timeout 2000)
+(def default-max-idle 8)
 
 ;;------------------------------------------------------------------------------
 ;; Helpers

--- a/src/org/purefn/starman/jedis.clj
+++ b/src/org/purefn/starman/jedis.clj
@@ -228,7 +228,9 @@
 
 (s/def ::config (s/keys :req [::host]
                         :opt [::port
+                              ::max-idle
                               ::max-total
+                              ::connect-timeout-ms
                               ::namespaces]))
 
 (s/fdef redis


### PR DESCRIPTION
Added configuration options for:
- maximum number of idle connections in the pool
- connection timeout when forming a new connection

Note that the default connection timeout is 2 seconds when the parameter is not specified in the pool constructor [[source](https://github.com/xetorthio/jedis/wiki/FAQ)]